### PR TITLE
Add Javax js-engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ ReactJS code.
 The pre-render the ReactJS components on the server side, the following libraries are used:
 - [/serverSide](http://play-react.herokuapp.com/serverSide) uses [trireme](https://github.com/apigee/trireme) provides a Node API on the JVM with Rhino
 - [/serverSide2](http://play-react.herokuapp.com/serverSide2) uses [js-engine](https://github.com/typesafehub/js-engine) that itself uses [trireme](https://github.com/apigee/trireme) behind [Akka](http://akka.io/) actors
+- /serverSideJavax uses [js-engine](https://github.com/typesafehub/js-engine) that itself uses the Javax engine
 - /serverSideNode uses [js-engine](https://github.com/typesafehub/js-engine) that itself uses NodeJS
 
 Pre rendering on the Server Side and streaming the page

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -5,7 +5,7 @@ import java.io.{ByteArrayOutputStream, File}
 import akka.actor.Props
 import akka.util.Timeout
 import com.typesafe.jse.Engine.JsExecutionResult
-import com.typesafe.jse.{Engine, Node, Trireme}
+import com.typesafe.jse.{Engine, Node, JavaxEngine, Trireme}
 import io.apigee.trireme.core._
 import play.api.Play.current
 import play.api._
@@ -55,6 +55,7 @@ object Application extends Controller {
     }
   }
 
+  def serverSideJavax = serverSideWithJsEngine(JavaxEngine.props())
 
   // with js-engine
   def serverSideTrireme = serverSideWithJsEngine(Trireme.props())

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,7 @@ GET        /                     controllers.Application.index
 GET        /clientSide           controllers.Application.clientSide
 GET        /serverSide           controllers.Application.serverSide
 GET        /serverSide2          controllers.Application.serverSideTrireme
+GET        /serverSideJavax      controllers.Application.serverSideJavax
 GET        /serverSideNode       controllers.Application.serverSideNode
 GET        /serverSideStream     controllers.Application.serverSideStream
 GET        /comments.json        controllers.Comments.list


### PR DESCRIPTION
Implements https://github.com/yanns/play-react/issues/2

It looks like js-engine does support Nashorn. I haven't gotten a chance to test this, so you may want to in order to make sure it works as expected.
